### PR TITLE
Upgraded Kotlin to v1.7.10

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.ricardorb.is_firebase_test_lab_activated'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
The previous version of Kotlin was preventing me from building, it caused the following error:
`The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.`

The version I'm using may be too high, though. 1.5.20 should be enough.
Thank you for this useful little package!