### PR TITLE
Add compatibility with AGP 8.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,11 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+      namespace 'com.ricardorb.is_firebase_test_lab_activated'
+    }
+
     compileSdkVersion 29
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,15 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
- Fixes https://github.com/RicardoRB/isfirebasetestlabactivated/issues/3

**The [second commit](https://github.com/RicardoRB/isfirebasetestlabactivated/pull/4/commits/b202f1561aa9e5ca46902c9c78e9278ed3763904) fixes the following error when using AGP 8:**

> 1: Task failed with an exception.
> -----------
> * What went wrong:
> Execution failed for task ':is_firebase_test_lab_activated:compileDebugKotlin'.
> > 'compileDebugJavaWithJavac' task (current target is 1.8) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
>   Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain

I assume this was just a warning before and is now treated as an error.