### PR TITLE
Moved from compileSdkVersion 29 to 34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,7 +30,7 @@ android {
       namespace 'com.ricardorb.is_firebase_test_lab_activated'
     }
 
-    compileSdkVersion 29
+    compileSdkVersion 34
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
I was getting this error on flutter 3.24.1:

/my_app/build/is_firebase_test_lab_activated/intermediates/merged_res/profile/values/values.xml:194: AAPT: error: resource android:attr/lStar not found.

Fixed by moving to compileSdkVersion 34.